### PR TITLE
[Feat] 핀 카테고리 추가 및 카테고리 데이터와 연결

### DIFF
--- a/ChagokChagok/ChagokChagok.xcodeproj/project.pbxproj
+++ b/ChagokChagok/ChagokChagok.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		E6BFBAE528587F5D003CCC5A /* UIcolors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFBAE428587F5D003CCC5A /* UIcolors.swift */; };
 		E6BFBB27285A29F4003CCC5A /* MyCourseListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFBB26285A29F4003CCC5A /* MyCourseListView.swift */; };
 		E6BFBB29285ACD78003CCC5A /* MyPinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFBB28285ACD78003CCC5A /* MyPinListView.swift */; };
+		E6BFBB31285ADD89003CCC5A /* PinCategoryScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFBB30285ADD89003CCC5A /* PinCategoryScroll.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -97,6 +98,7 @@
 		E6BFBAE428587F5D003CCC5A /* UIcolors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIcolors.swift; sourceTree = "<group>"; };
 		E6BFBB26285A29F4003CCC5A /* MyCourseListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCourseListView.swift; sourceTree = "<group>"; };
 		E6BFBB28285ACD78003CCC5A /* MyPinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPinListView.swift; sourceTree = "<group>"; };
+		E6BFBB30285ADD89003CCC5A /* PinCategoryScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinCategoryScroll.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 				3870D8552857155A0067F44A /* RecentRecord.swift */,
 				3870D85D2857970F0067F44A /* MyFavoriteView.swift */,
 				3870D8842859F3A90067F44A /* CategoryScroll.swift */,
+				E6BFBB30285ADD89003CCC5A /* PinCategoryScroll.swift */,
 				3870D8862859F6BD0067F44A /* CategoryData.swift */,
 				3870D8882859F7030067F44A /* SelectCourseCategoryView.swift */,
 				3870D88A2859F80C0067F44A /* SelectPinCategoryView.swift */,
@@ -382,6 +385,7 @@
 				8CD1F30E2859C45900E5C2DA /* Persistence.swift in Sources */,
 				8C06B7EE285326D00057C5FC /* PinDetailView.swift in Sources */,
 				CD943D9928584B760076A794 /* LocationsView.swift in Sources */,
+				E6BFBB31285ADD89003CCC5A /* PinCategoryScroll.swift in Sources */,
 				3870D8892859F7030067F44A /* SelectCourseCategoryView.swift in Sources */,
 				CD943D9528584A820076A794 /* LocationsViewModel.swift in Sources */,
 				CD943DA42858560A0076A794 /* LocationsData.swift in Sources */,

--- a/ChagokChagok/ChagokChagok/CategoryScroll.swift
+++ b/ChagokChagok/ChagokChagok/CategoryScroll.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
-struct CategoryScroll: View {
+struct CourseCategoryScroll: View {
     @Binding var selectedCategory: [CourseCategory.RawValue]
     
     var body: some View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8.0) {
                     ForEach(CourseCategory.allCases, id: \.self) { item in
-                        CategoryList(item: item.rawValue, selected: $selectedCategory)
+                        CourseCategoryList(item: item.rawValue, selected: $selectedCategory)
                     }
                 }
             }
     }
 }
 
-struct CategoryList: View {
+struct CourseCategoryList: View {
     let item: String
     @Binding var selected: [String]
     

--- a/ChagokChagok/ChagokChagok/MyCourseListView.swift
+++ b/ChagokChagok/ChagokChagok/MyCourseListView.swift
@@ -21,7 +21,7 @@ struct MyCourseListView: View {
             }
             .padding(EdgeInsets(top: 60.0, leading: 20.0, bottom: 0, trailing: 0))
             .frame(maxWidth: .infinity, alignment: .leading)
-            CategoryScroll(selectedCategory: $selectedCategory)
+            CourseCategoryScroll(selectedCategory: $selectedCategory)
                 .padding(EdgeInsets(top: 33.0, leading: 20.0, bottom: 0, trailing: 0))
             Text("Total ")
                 .font(.system(size: 14, weight: .regular))

--- a/ChagokChagok/ChagokChagok/MyPinListView.swift
+++ b/ChagokChagok/ChagokChagok/MyPinListView.swift
@@ -21,7 +21,7 @@ struct MyPinListView: View {
             }
             .padding(EdgeInsets(top: 60.0, leading: 20.0, bottom: 0, trailing: 0))
             .frame(maxWidth: .infinity, alignment: .leading)
-            CategoryScroll(selectedCategory: $selectedCategory)
+            PinCategoryScroll(selectedCategory: $selectedCategory)
                 .padding(EdgeInsets(top: 33.0, leading: 20.0, bottom: 0, trailing: 0))
             Text("Total ")
                 .font(.system(size: 14, weight: .regular))

--- a/ChagokChagok/ChagokChagok/PinCategoryScroll.swift
+++ b/ChagokChagok/ChagokChagok/PinCategoryScroll.swift
@@ -1,20 +1,26 @@
+//
+//  PinCategoryScroll.swift
+//  ChagokChagok
+//
+//  Created by 윤가희 on 2022/06/16.
+//
 import SwiftUI
 
-struct CategoryScroll: View {
-    @Binding var selectedCategory: [CourseCategory.RawValue]
+struct PinCategoryScroll: View {
+    @Binding var selectedCategory: [PinCategory.RawValue]
     
     var body: some View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8.0) {
-                    ForEach(CourseCategory.allCases, id: \.self) { item in
-                        CategoryList(item: item.rawValue, selected: $selectedCategory)
+                    ForEach(PinCategory.allCases, id: \.self) { item in
+                        PinCategoryList(item: item.rawValue, selected: $selectedCategory)
                     }
                 }
             }
     }
 }
 
-struct CategoryList: View {
+struct PinCategoryList: View {
     let item: String
     @Binding var selected: [String]
     


### PR DESCRIPTION
## 이슈 번호 #13 
## 작업내용
- PinCategoryScroll을 생성했습니다
- 카테고리 스크롤 인디케이터를 제거했습니다
- CategoryScroll View에 CategoryData를 연결했습니다.

## 리뷰포인트
- [ ] 기존 CategoryScroll 구조에 CategoryData의 핀 카테고리와 코스 카테고리를 상황에 맞게 넣는것을 상상했었는데, 생각대로 되지 않아 그냥 각각 두 가지의 파일을 만들었습니다.. 더 좋은 방법이 있다면 알려주시면 감사하겠습니다!
