### PR TITLE
[Fix] MainView Title 깨지는 문제

### DIFF
--- a/ChagokChagok/ChagokChagok/ContentView.swift
+++ b/ChagokChagok/ChagokChagok/ContentView.swift
@@ -11,12 +11,16 @@ struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @State var firstNaviLinkActive = false
     
+    init() {
+        UINavigationBar.appearance().largeTitleTextAttributes = [.font : UIFont(name: "AppleSDGothicNeo-Bold", size: 26)!]
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
                 Color.backGround.ignoresSafeArea()
                 MainView(firstNaviLinkActive: $firstNaviLinkActive)
-                    .navigationTitle("차곡차곡")
+                    .navigationBarTitle("차곡차곡")
             }
         }
     }

--- a/ChagokChagok/ChagokChagok/ContentView.swift
+++ b/ChagokChagok/ChagokChagok/ContentView.swift
@@ -15,13 +15,8 @@ struct ContentView: View {
         NavigationView {
             ZStack {
                 Color.backGround.ignoresSafeArea()
-                VStack(alignment: .leading, spacing: 0) {
-                    Text("차곡차곡")
-                        .font(.title)
-                        .bold()
-                        .padding(.leading, 16)
-                    MainView(firstNaviLinkActive: $firstNaviLinkActive)
-                }
+                MainView(firstNaviLinkActive: $firstNaviLinkActive)
+                    .navigationTitle("차곡차곡")
             }
         }
     }

--- a/ChagokChagok/ChagokChagok/ContentView.swift
+++ b/ChagokChagok/ChagokChagok/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @State var firstNaviLinkActive = false
     
     init() {
-        UINavigationBar.appearance().largeTitleTextAttributes = [.font : UIFont(name: "AppleSDGothicNeo-Bold", size: 26)!]
+        UINavigationBar.appearance().largeTitleTextAttributes = [.font: UIFont(name: "AppleSDGothicNeo-Bold", size: 26)!]
     }
     
     var body: some View {

--- a/ChagokChagok/ChagokChagok/ContentView.swift
+++ b/ChagokChagok/ChagokChagok/ContentView.swift
@@ -10,22 +10,18 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @State var firstNaviLinkActive = false
-
+    
     var body: some View {
         NavigationView {
             ZStack {
                 Color.backGround.ignoresSafeArea()
-                MainView(firstNaviLinkActive: $firstNaviLinkActive)
-                    .padding(.top, 47)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Text("차곡차곡 🚙")
-                                .padding(EdgeInsets(top: 80, leading: 16, bottom: 16, trailing: 16))
-                                .font(.system(size: 26).weight(.semibold))
-                        }
-                    }
-                    .navigationBarTitleDisplayMode(.inline)
-                    .padding(.all, 16)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("차곡차곡")
+                        .font(.title)
+                        .bold()
+                        .padding(.leading, 16)
+                    MainView(firstNaviLinkActive: $firstNaviLinkActive)
+                }
             }
         }
     }

--- a/ChagokChagok/ChagokChagok/MainView.swift
+++ b/ChagokChagok/ChagokChagok/MainView.swift
@@ -14,8 +14,8 @@ struct MainView: View {
             myFavoriteBtn
             RecentRecord(image: "tempPin", name: "이름 미정", memo: "메모를 수정해라아아악", createTime: "2022.03.12", type: "핀", isFavorite: true)
                 .padding()
-            Spacer()
         }
+        .padding(.top, 22)
     }
     
     // TODO: 디자인 픽스되면 버튼 View로 변경 예정

--- a/ChagokChagok/ChagokChagok/MainView.swift
+++ b/ChagokChagok/ChagokChagok/MainView.swift
@@ -13,7 +13,6 @@ struct MainView: View {
             }
             myFavoriteBtn
             RecentRecord(image: "tempPin", name: "이름 미정", memo: "메모를 수정해라아아악", createTime: "2022.03.12", type: "핀", isFavorite: true)
-                .padding()
         }
         .padding(.top, 22)
     }


### PR DESCRIPTION
# 🚙 이슈번호 #61 
# 🚙 작업내용
- mainView 에서 Toolbar로 들어가있는 제목을 navigationbarTitle로 변경하였습니다.
- navigationbartitle 의 폰트는 애플산돌고딕, 사이즈는 26으로 피그마 와이어프래임과 동일하게 수정하였습니다.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/96969693/174446876-9ecd57d4-3878-4a1d-b7e6-a2e9c0e18ea5.png">