### PR TITLE
[Feat] 즐겨찾기 없을 때 대체텍스트 띄우는 기능 추가

### DIFF
--- a/ChagokChagok/ChagokChagok/MyFavoriteView.swift
+++ b/ChagokChagok/ChagokChagok/MyFavoriteView.swift
@@ -8,12 +8,14 @@ struct MyFavoriteView: View {
     
     var pin = Pin()
     var course = Course()
-    @State private var count = 0
     
     var body: some View {
         VStack {
+            Text("Total \(pins.count + courses.count)")
+                .foregroundColor(.gray)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(EdgeInsets(top: 40, leading: 16, bottom: 20, trailing: 16))
             myFavoriteList()
-            Spacer()
         }
     }
     

--- a/ChagokChagok/ChagokChagok/MyFavoriteView.swift
+++ b/ChagokChagok/ChagokChagok/MyFavoriteView.swift
@@ -8,15 +8,24 @@ struct MyFavoriteView: View {
     
     var pin = Pin()
     var course = Course()
-    
+
     var body: some View {
         VStack {
-            Text("Total \(pins.count + courses.count)")
-                .foregroundColor(.gray)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(EdgeInsets(top: 40, leading: 16, bottom: 20, trailing: 16))
-            myFavoriteList()
+            if pins.count + courses.count == 0 {
+                replaceText
+            } else {
+                Text("Total \(pins.count + courses.count)")
+                    .foregroundColor(.gray)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(EdgeInsets(top: 40, leading: 16, bottom: 20, trailing: 16))
+                myFavoriteList()
+            }
         }
+    }
+    
+    var replaceText: some View {
+        Text("😃 아무고토없지롱 즐겨찾기를 눌러주세염.")
+            .bold()
     }
     
     private func myFavoriteList() -> some View {

--- a/ChagokChagok/ChagokChagok/MyFavoriteView.swift
+++ b/ChagokChagok/ChagokChagok/MyFavoriteView.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 struct MyFavoriteView: View {
     @Environment(\.managedObjectContext) private var viewContext
-
     @FetchRequest(entity: Pin.entity(), sortDescriptors: [], predicate: NSPredicate(format: "isFavorite == %@", "1"), animation: .default) private var pins: FetchedResults<Pin>
-    
     @FetchRequest(entity: Course.entity(), sortDescriptors: [], predicate: NSPredicate(format: "isFavorite == %@", "1"),
                   animation: .default) private var courses: FetchedResults<Course>
     
@@ -13,48 +11,33 @@ struct MyFavoriteView: View {
     
     var body: some View {
         VStack {
-//            myFavoriteCount()
-            
             myFavoriteList()
-            
             Spacer()
         }
     }
     
     private func myFavoriteList() -> some View {
         VStack {
-                List {
-                    ForEach(pins) { pin in
-                        NavigationLink {
-                            PinDetailView(pin: pin)
-                        } label: {
-                            ListCell(pin: pin)
-                        }
-                    }
-                    ForEach(courses) { course in
-                        if course.isFavorite {
-                            NavigationLink {
-                                CourseDetailView(course: course)
-                            } label: {
-                                ListCellForCourse(course: course)
-                            }
-                        }
+            List {
+                ForEach(pins) { pin in
+                    NavigationLink {
+                        PinDetailView(pin: pin)
+                    } label: {
+                        ListCell(pin: pin)
                     }
                 }
-                .listStyle(.plain)
+                
+                ForEach(courses) { course in
+                    NavigationLink {
+                        CourseDetailView(course: course)
+                    } label: {
+                        ListCellForCourse(course: course)
+                    }
+                }
+            }
+            .listStyle(.plain)
         }
     }
-    
-//        private func myFavoriteCount() {
-//            ForEach(pins) { pin in
-//                pinCount += Int(pin.isFavorite)
-//            }
-//
-//            Text("Total \(pins.contains(Int(pin.isFavorite)))")
-//                .font(.system(size: 14))
-//                .frame(maxWidth: .infinity, alignment: .leading)
-//                .padding(.horizontal, 20)
-//        }
 }
 
 struct MyFavoriteView_Previews: PreviewProvider {

--- a/ChagokChagok/ChagokChagok/MyFavoriteView.swift
+++ b/ChagokChagok/ChagokChagok/MyFavoriteView.swift
@@ -8,6 +8,7 @@ struct MyFavoriteView: View {
     
     var pin = Pin()
     var course = Course()
+    @State private var count = 0
     
     var body: some View {
         VStack {
@@ -17,26 +18,24 @@ struct MyFavoriteView: View {
     }
     
     private func myFavoriteList() -> some View {
-        VStack {
-            List {
-                ForEach(pins) { pin in
-                    NavigationLink {
-                        PinDetailView(pin: pin)
-                    } label: {
-                        ListCell(pin: pin)
-                    }
-                }
-                
-                ForEach(courses) { course in
-                    NavigationLink {
-                        CourseDetailView(course: course)
-                    } label: {
-                        ListCellForCourse(course: course)
-                    }
+        List {
+            ForEach(pins) { pin in
+                NavigationLink {
+                    PinDetailView(pin: pin)
+                } label: {
+                    ListCell(pin: pin)
                 }
             }
-            .listStyle(.plain)
+            
+            ForEach(courses) { course in
+                NavigationLink {
+                    CourseDetailView(course: course)
+                } label: {
+                    ListCellForCourse(course: course)
+                }
+            }
         }
+        .listStyle(.plain)
     }
 }
 


### PR DESCRIPTION
# 🚙 이슈번호 #64 

# 🚙 작업 내용
- 즐겨찾기 내용이 아무것도 없을 때 대체택스트를 띄워줍니다. (왼쪽)
- 즐겨찾기가 있을 때, total 값을 띄워줍니다. (오른쪽)

<img width="290" alt="image" src="https://user-images.githubusercontent.com/96969693/174451236-adf592da-982b-40e8-b35c-c459dec6acfd.png"><img width="281" alt="image" src="https://user-images.githubusercontent.com/96969693/174451246-16f1ac0b-bb20-4aa9-816c-0b7d0dcbac1b.png">

# 🚙 ETC
- 어떤 문구를 넣을지에 대해서는 다시 이야기해봐야합니다.
- swiftLint에서 isEmpty 를 사용하지 않으면 빌드에러를 주는 조건을 삭제해야합니다. 

# 🚙 질문
지금은 ==0 을 활용해서 조건문을 이용했습니다. ==0 보다 isEmpty를 사용하는 것이 더 효율적이라고 알고있어서 아래처럼 사용하고 싶었지만,
```
if pins.count.words.isEmpty, pins.count.words.isEmpty {
  replaceText
}
```
근데 이렇게 조건을 주면, replaceText를 출력하지 않더군요. 아마 조건문을 통과하지 않는 것 같습니다. 근데 ```words.isEmpty``` 의 의미는 0의 의미와 같은데 왜 조건문을 통과하지 않는 걸까요..? 이 문제떄문에 swiftLiint까지 손대야할 것 같습니다 ㅠㅠ 


