### PR TITLE
[Chore] isEmpty 관련 lint 규칙 제거

### DIFF
--- a/ChagokChagok/.swiftlint.yml
+++ b/ChagokChagok/.swiftlint.yml
@@ -8,16 +8,19 @@ disabled_rules: # Default Rules에서 비활성화할 규칙
     
     # 강제 언래핑은 피해야합니다. https://realm.github.io/SwiftLint/force_unwrapping.html
     - force_unwrapping
+    
+    # isEmpty 안썼을 때 빌드에러나는 조건을 무시합니다.
+    - empty_count
 
 opt_in_rules:
-  # .count==0 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_count.html
-  - empty_count
-  
-  # 빈 String 문자열과 비교하는 것 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_string.html
-  - empty_string
+    # .count==0 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_count.html
+    - empty_count
+    
+    # 빈 String 문자열과 비교하는 것 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_string.html
+    - empty_string
 
 excluded: # SwiftLint 검사에서 제외할 파일 경로
-  - Pods
+    - Pods
 
 line_length: # 한 줄에 250자 이상일 때 경고를 줍니다.
     warning: 250


### PR DESCRIPTION
# 🚙 이슈번호 #64 

# 🚙 작업 내용
- 조건문을 사용하기 위해서 isEmpty 사용을 권장하는 lint 조건을 제거했습니다.

# 🚙 PR 포인트
- isEmpty를 사용해서 조건문을 사용하는 방법에 대해서 알고 넘어가야합니다.
```
if pins.count.words.isEmpty, pins.count.words.isEmpty {
  replaceText
}
```
이렇게 조건을 주면, replaceText를 출력하지 못하던데, 왜 그런지 이유를 알고 넘어가야합니다 ㅠ  -> #65 