### PR TITLE
[Fix] 리스트 패딩값 수정 및 즐겨찾기 버튼 수정

### DIFF
--- a/ChagokChagok/ChagokChagok/ListCell.swift
+++ b/ChagokChagok/ChagokChagok/ListCell.swift
@@ -12,7 +12,7 @@ struct ListCell: View {
                 .padding(.trailing, 16)
             listText
             Spacer()
-            isfavoriteBtn
+            FavoriteButtonForPin(pin: pin)
         }
         .frame(width: 350, height: 104, alignment: .leading)
     }
@@ -38,15 +38,4 @@ struct ListCell: View {
                 .listMemoSpaceStyle()
         }
     }
-    
-    private var isfavoriteBtn: some View {
-        Button(action: {
-            // action
-        }, label: {
-            Image(systemName: pin.isFavorite ? "heart.fill" : "heart")
-                .frame(width: 20, height: 20, alignment: .topTrailing)
-                .padding(.top, 5)
-        })
-    }
-    
 }

--- a/ChagokChagok/ChagokChagok/ListCell.swift
+++ b/ChagokChagok/ChagokChagok/ListCell.swift
@@ -39,12 +39,14 @@ struct ListCell: View {
         }
     }
     
-    var isfavoriteBtn: some View {
-        VStack {
+    private var isfavoriteBtn: some View {
+        Button(action: {
+            // action
+        }, label: {
             Image(systemName: pin.isFavorite ? "heart.fill" : "heart")
                 .frame(width: 20, height: 20, alignment: .topTrailing)
                 .padding(.top, 5)
-        }
+        })
     }
     
 }

--- a/ChagokChagok/ChagokChagok/ListCell.swift
+++ b/ChagokChagok/ChagokChagok/ListCell.swift
@@ -7,32 +7,29 @@ struct ListCell: View {
     var pin = Pin()
         
     var body: some View {
-
-        HStack {
-            listImage
-                .padding(.trailing, 16)
-            listText
-            Spacer()
-            isfavoriteBtn
+        GeometryReader { geo in
+            HStack {
+                listImage
+                    .padding(.trailing, 16)
+                listText
+                Spacer()
+                isfavoriteBtn
+            }
+            .frame(width: geo.size.width, height: 104, alignment: .leading)
         }
-        .frame(width: 350, height: 92)
     }
     
-    var listImage: some View {
+    private var listImage: some View {
         Image(pin.category ?? "핀")
             .listIconStyle()
     }
     
-    var listText: some View {
+    private var listText: some View {
         VStack(alignment: .leading, spacing: 7) {
             HStack {
                 Image("pinIcon")
                     .resizable()
-                    .frame(width: 13, height: 17)
-                    .padding(.bottom, 4)
-//                Text(data.type == 1 ? "tempTypeImage" : "tmepTypeImage")
-//                    .foregroundColor(.gray)
-//                    .font(.system(size: 12))
+                    .frame(width: 16, height: 13, alignment: .leading)
                 Text(pin.name ?? dateFormat.string(from: pin.date!))
                     .listTitleStyle()
                     .listTextSpaceStyle()

--- a/ChagokChagok/ChagokChagok/ListCell.swift
+++ b/ChagokChagok/ChagokChagok/ListCell.swift
@@ -2,21 +2,19 @@ import SwiftUI
 
 struct ListCell: View {
     @FetchRequest(entity: Pin.entity(), sortDescriptors: [NSSortDescriptor(keyPath: \Pin.date, ascending: false)],
-        animation: .default) private var pins: FetchedResults<Pin>
+                  animation: .default) private var pins: FetchedResults<Pin>
     
     var pin = Pin()
-        
+    
     var body: some View {
-        GeometryReader { geo in
-            HStack {
-                listImage
-                    .padding(.trailing, 16)
-                listText
-                Spacer()
-                isfavoriteBtn
-            }
-            .frame(width: geo.size.width, height: 104, alignment: .leading)
+        HStack {
+            listImage
+                .padding(.trailing, 16)
+            listText
+            Spacer()
+            isfavoriteBtn
         }
+        .frame(width: 350, height: 104, alignment: .leading)
     }
     
     private var listImage: some View {

--- a/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
@@ -41,14 +41,12 @@ struct ListCellForCourse: View {
     }
     
     private var isfavoriteBtn: some View {
-        VStack {
-            Button(action: {
-                // action
-            }, label: {
-                Image(systemName: course.isFavorite ? "heart.fill" : "heart")
-                    .frame(width: 20, height: 20, alignment: .topTrailing)
-                    .padding(.top, 5)
-            })
-        }
+        Button(action: {
+            // action
+        }, label: {
+            Image(systemName: course.isFavorite ? "heart.fill" : "heart")
+                .frame(width: 20, height: 20, alignment: .topTrailing)
+                .padding(.top, 5)
+        })
     }
 }

--- a/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
@@ -2,36 +2,34 @@ import SwiftUI
 
 struct ListCellForCourse: View {
     @FetchRequest(entity: Course.entity(), sortDescriptors: [],
-        animation: .default) private var courses: FetchedResults<Course>
+                  animation: .default) private var courses: FetchedResults<Course>
     
     var course = Course()
     
     var body: some View {
-        HStack {
-            listImage
-                .padding(.trailing, 16)
-            listText
-            Spacer()
-            isfavoriteBtn
+        GeometryReader { geo in
+            HStack {
+                listImage
+                listText
+                    .padding(.leading, 17)
+                Spacer()
+                isfavoriteBtn
+            }
+            .frame(width: geo.size.width, height: 104, alignment: .leading)
         }
-        .frame(width: 350, height: 92)
     }
     
-    var listImage: some View {
+    private var listImage: some View {
         Image(course.category ?? "코스")
             .listIconStyle()
     }
     
-    var listText: some View {
+    private var listText: some View {
         VStack(alignment: .leading, spacing: 7) {
             HStack {
                 Image("courseIcon")
                     .resizable()
                     .frame(width: 16, height: 13, alignment: .leading)
-                    .padding(.bottom, 6)
-//                Text(data.type == 1 ? "tempTypeImage" : "tmepTypeImage")
-//                    .foregroundColor(.gray)
-//                    .font(.system(size: 12))
                 Text(course.name ?? dateFormat.string(from: course.date!))
                     .listTitleStyle()
                     .listTextSpaceStyle()

--- a/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
@@ -7,16 +7,14 @@ struct ListCellForCourse: View {
     var course = Course()
     
     var body: some View {
-        GeometryReader { geo in
-            HStack {
-                listImage
-                listText
-                    .padding(.leading, 17)
-                Spacer()
-                isfavoriteBtn
-            }
-            .frame(width: geo.size.width, height: 104, alignment: .leading)
+        HStack {
+            listImage
+                .padding(.trailing, 16)
+            listText
+            Spacer()
+            isfavoriteBtn
         }
+        .frame(width: 350, height: 104)
     }
     
     private var listImage: some View {
@@ -30,6 +28,7 @@ struct ListCellForCourse: View {
                 Image("courseIcon")
                     .resizable()
                     .frame(width: 16, height: 13, alignment: .leading)
+                    .padding(.bottom, 6)
                 Text(course.name ?? dateFormat.string(from: course.date!))
                     .listTitleStyle()
                     .listTextSpaceStyle()

--- a/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
@@ -41,11 +41,15 @@ struct ListCellForCourse: View {
         }
     }
     
-    var isfavoriteBtn: some View {
+    private var isfavoriteBtn: some View {
         VStack {
-            Image(systemName: course.isFavorite ? "heart.fill" : "heart")
-                .frame(width: 20, height: 20, alignment: .topTrailing)
-                .padding(.top, 5)
+            Button(action: {
+                // action
+            }, label: {
+                Image(systemName: course.isFavorite ? "heart.fill" : "heart")
+                    .frame(width: 20, height: 20, alignment: .topTrailing)
+                    .padding(.top, 5)
+            })
         }
     }
 }

--- a/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/ListCellForCourse.swift
@@ -12,7 +12,7 @@ struct ListCellForCourse: View {
                 .padding(.trailing, 16)
             listText
             Spacer()
-            isfavoriteBtn
+            FavoriteButtonForCourse(course: course)
         }
         .frame(width: 350, height: 104)
     }
@@ -38,15 +38,5 @@ struct ListCellForCourse: View {
                 .listMemoStyle()
                 .listMemoSpaceStyle()
         }
-    }
-    
-    private var isfavoriteBtn: some View {
-        Button(action: {
-            // action
-        }, label: {
-            Image(systemName: course.isFavorite ? "heart.fill" : "heart")
-                .frame(width: 20, height: 20, alignment: .topTrailing)
-                .padding(.top, 5)
-        })
     }
 }


### PR DESCRIPTION
# 🚙 이슈번호 #69 
# 🚙 작업내용
- 원래 geometry reader로 리스트 내 frame을 조절하려고 하였으나 그냥 원래대로 임시 수치로 조절하였습니다.
- 리스트 에서 바로 하트를 누를수 있도록 하트를 일단 image 에서 button으로 수정하였습니다.

<img width="380" alt="image" src="https://user-images.githubusercontent.com/96969693/174465698-90fa99b6-2da8-478a-8513-91782c84dd3d.png">

# 🚙 ETC
- #67  먼저 머지해야합니다. zstack으로 리스트를 한번 감싸주고, 그 위에 cell을 올림으로써 favorite button이 작동할 수 있습니다.

# 🚙 추후 개발해야할 것
- 즐겨찾기 버튼을 누르면, 하트가 바뀌긴하는데 navigationLink로 연결되어있따보니 바로 상세페이지로넘어가는 버그가 존재합니다. 추후 이 문제도 해결해야합니다.