### PR TITLE
[Add] Course Detail View에 map 추가

### DIFF
--- a/ChagokChagok/ChagokChagok/View/CourseView/CourseDetailView.swift
+++ b/ChagokChagok/ChagokChagok/View/CourseView/CourseDetailView.swift
@@ -5,61 +5,70 @@
 //  Created by Youngwoong Choi on 2022/06/14.
 //
 
+import MapKit
 import SwiftUI
 
 struct CourseDetailView: View {
     @Environment(\.managedObjectContext) private var viewContext
+    @StateObject private var locationManager = LocationManager()
     
     @FetchRequest(entity: Course.entity(), sortDescriptors: [],
         animation: .default) private var courses: FetchedResults<Course>
-       
-    var course = Course()
+    @FetchRequest(entity: Pin.entity(), sortDescriptors: [],
+        animation: .default) private var pins: FetchedResults<Pin>
     
-    var body: some View {
-        VStack {
-            HStack {
-                Image(course.category ?? "코스")
-                    .resizable()
-                    .frame(width: 76, height: 76, alignment: .leading)
-                
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(dateFormat.string(from: course.date ?? Date()))
-                        .font(.system(size: 15))
-                        .foregroundColor(.gray)
+    // MARK: 임시로 pin 데이터를 넣어줌 (지도넣을라고)
+    var pin = Pin()
+    var course = Course()
 
-                    Text(course.name ?? "제목을 써주세요")
-                        .font(.system(size: 22))
-                        .fontWeight(.bold)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.5)
+    var body: some View {
+        GeometryReader { geo in
+            VStack(spacing: 22) {
+                HStack {
+                    Image(course.category ?? "코스")
+                        .resizable()
+                        .frame(width: 76, height: 76, alignment: .leading)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(dateFormat.string(from: course.date ?? Date()))
+                            .font(.system(size: 15))
+                            .foregroundColor(.gray)
+
+                        Text(course.name ?? "제목을 써주세요")
+                            .font(.system(size: 22))
+                            .fontWeight(.bold)
+                            .lineLimit(1)
+                    }
+                        .padding(.leading, 24)
                 }
-                .padding(.leading, 24)
-                
-                Spacer()
+                    .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 17.5))
+                    .frame(width: geo.size.width, alignment: .leading)
+
+                Map(coordinateRegion: $locationManager.mapRegion,
+                    showsUserLocation: true,
+                    annotationItems: pins,
+                    annotationContent: { pin in MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: 36.0189315, longitude: 129.3429384)) {
+                            LocationMapAnnotationView()
+                                .scaleEffect(pin == pin ? 1.1 : 0.8)
+                                .shadow(radius: 10)
+                                .onTapGesture {
+//                            viewModel.showNextLocation(location: pin)
+                            }
+                        }
+                    })
+                    .frame(width: geo.size.width * 0.9, height: geo.size.width * 0.95)
+                    .cornerRadius(14)
+
+                Text(course.memo ?? "내용 없음")
+                    .font(.system(size: 15))
+                    .padding(.horizontal, 20)
+                    .frame(width: geo.size.width, alignment: .leading)
             }
-            .frame(width: 350, height: 80, alignment: .leading)
-            .padding(.top, 45)
-            
-//            Map(coordinateRegion: .constant(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: pin.latitude, longitude: pin.longitude),
-//        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))), interactionModes: .all, showsUserLocation: true, annotationItems: pins, annotationContent: { pin in
-//                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: pin.latitude, longitude: pin.longitude)) {
-//                    Image(systemName: "mappin")
-//                        .foregroundColor(.pink)
-//                }
-//            })
-//                .frame(width: 350, height: 350)
-//                .cornerRadius(14)
-//                .padding(22)
-            
-            Text(course.memo ?? "내용 없음")
-                .font(.system(size: 15))
-                .frame(width: 350, height: 100, alignment: .topLeading)
-            
-            Spacer()
+                .frame(width: geo.size.width, height: geo.size.height * 0.9, alignment: .top)
         }
-        .navigationTitle("")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
             ToolbarItem(placement: .principal) {
                 HStack {
                     Image("courseIcon")
@@ -71,7 +80,7 @@ struct CourseDetailView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack {
                     FavoriteButtonForCourse(course: course)
-                    
+
                     NavigationLink {
                         CourseEditView(course: course, textFieldName: course.name ?? "", textFieldMemo: course.memo ?? "")
                     } label: {


### PR DESCRIPTION
# 🚙 이슈번호 #71 
# 🚙 작업내용
- 코스 상세페이지에 지도를 추가했습니다.
- 지도를 넣었을때 간격을 spacer 대신 geometryReader를 사용해서 수정했습니다.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/96969693/174469195-8e951702-396a-4024-a47b-02f5149985af.png">

# 🚙 ETC
- 지도위에 코스가 들어가있는 기능구현이 아직 되지 않았기 때문에 pin 지도를 따왔습니다. 그래서 pin 관련한 map이 들어가있습니다.
- 6월 19일 오늘 논의 후, 이미지를 제작하여 이미지를 dummy data로 넣는 방법에 대해 고민해봐야 합니다.
